### PR TITLE
Find missing stop and really buttons

### DIFF
--- a/test8.py
+++ b/test8.py
@@ -677,9 +677,13 @@ class MultiUserUhmegleBot:
 
             # Шаг 1. Нажимаем «Stop»
             if not await self._click_first_visible([
-                'button:has-text("Stop")',
-                'div:has-text("Stop")',
-                '[class*="stop"]',
+                # Возможные варианты расположения Stop-кнопки
+                'button:has-text("Stop")',                 # Кнопка
+                'div:has-text("Stop")',                    # Вложенный div с текстом
+                'div.bottomButton.stop',                    # Контейнер-кнопка
+                'div.bottomButton.skipButton.stop',         # Полный набор классов
+                '[class*="skipButton"][class*="stop"]',   # Комбинация классов
+                '[class*="stop"]',                         # Любой элемент с классом stop
             ], "Stop"):
                 print("⚠️ Кнопка Stop не найдена. Пропускаем завершение чата ...")
 
@@ -688,9 +692,13 @@ class MultiUserUhmegleBot:
 
             # Шаг 2. Подтверждаем «Really»
             await self._click_first_visible([
-                'button:has-text("Really")',
-                'div:has-text("Really")',
-                '[class*="really"]',
+                # Возможные варианты расположения Really-кнопки (подтверждение)
+                'button:has-text("Really")',               # Кнопка
+                'div:has-text("Really")',                  # Вложенный div с текстом
+                'div.bottomButton.really',                  # Контейнер-кнопка
+                'div.bottomButton.skipButton.really',       # Полный набор классов
+                '[class*="skipButton"][class*="really"]', # Комбинация классов
+                '[class*="really"]',                       # Любой элемент с классом really
             ], "Really")
 
             # Ждём появления кнопки для нового собеседника


### PR DESCRIPTION
Expand selectors for "Stop" and "Really" buttons to improve their detection.

The previous selectors were insufficient for finding the buttons, causing the script to fail when the HTML structure varied. The new selectors include additional class combinations (`bottomButton`, `skipButton`) to increase robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-429eddf3-e9ed-4e17-9009-3687d9b4935d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-429eddf3-e9ed-4e17-9009-3687d9b4935d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

